### PR TITLE
Update: Remove unnecessary await from synchronous schema.validate calls

### DIFF
--- a/lib/MailerModule.js
+++ b/lib/MailerModule.js
@@ -93,7 +93,7 @@ class MailerModule extends AbstractModule {
     try {
       const jsonschema = await this.app.waitForModule('jsonschema')
       const schema = await jsonschema.getSchema('maildata')
-      await schema.validate(data)
+      schema.validate(data)
 
       await this.getTransport().send(data)
 

--- a/tests/MailerModule.spec.js
+++ b/tests/MailerModule.spec.js
@@ -18,7 +18,7 @@ const mockServer = {
 }
 const mockJsonSchema = {
   getSchema: mock.fn(async () => ({
-    validate: mock.fn(async () => {})
+    validate: mock.fn(() => {})
   }))
 }
 
@@ -69,7 +69,7 @@ describe('MailerModule', () => {
   beforeEach(async () => {
     logCalls.length = 0
     mockJsonSchema.getSchema = mock.fn(async () => ({
-      validate: mock.fn(async () => {})
+      validate: mock.fn(() => {})
     }))
     mailer = new MailerModule(mockApp, { name: 'adapt-authoring-mailer', rootDir: moduleRootDir })
     await mailer.onReady()
@@ -310,7 +310,7 @@ describe('MailerModule', () => {
     })
 
     it('should validate data against the maildata schema', async () => {
-      const validateFn = mock.fn(async () => {})
+      const validateFn = mock.fn(() => {})
       mockJsonSchema.getSchema = mock.fn(async (name) => {
         assert.equal(name, 'maildata')
         return { validate: validateFn }
@@ -368,7 +368,7 @@ describe('MailerModule', () => {
 
     it('should throw MAIL_SEND_FAILED when schema validation fails', async () => {
       mockJsonSchema.getSchema = mock.fn(async () => ({
-        validate: mock.fn(async () => { throw new Error('validation failed') })
+        validate: mock.fn(() => { throw new Error('validation failed') })
       }))
       mailer.transports.smtp = {
         name: 'smtp',


### PR DESCRIPTION
### Fixes adapt-security/adapt-authoring-jsonschema#58

### Update
* Remove `await` from `schema.validate()` in `MailerModule.send()` — now synchronous in adapt-schemas v3
* Update test mocks to reflect synchronous `validate` signature

### Testing
1. Run `npm test`
2. Verify email sending still validates data correctly

Depends on https://github.com/adapt-security/adapt-authoring-jsonschema/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)