### PR TITLE
Update: Distinguish SMTP connection failures from send failures

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -3,8 +3,12 @@
     "description": "Email functionality is not enabled",
     "statusCode": 500
   },
+  "MAIL_CONNECTION_FAILED": {
+    "description": "Could not connect to the mail server",
+    "statusCode": 502
+  },
   "MAIL_SEND_FAILED": {
-    "description": "Failed to send error email",
+    "description": "Failed to send email",
     "statusCode": 500
   }
 }

--- a/lib/MailerModule.js
+++ b/lib/MailerModule.js
@@ -3,6 +3,17 @@ import { loadRouteConfig, registerRoutes } from 'adapt-authoring-server'
 import AbstractMailTransport from './AbstractMailTransport.js'
 import FilesystemTransport from './transports/FilesystemTransport.js'
 import SmtpTransport from './transports/SmtpTransport.js'
+
+// Node/nodemailer codes that mean the mail server was unreachable, as opposed
+// to the message being rejected — lets us flag the difference to operators.
+const CONNECTION_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ECONNECTION', 'ETIMEDOUT', 'ESOCKET', 'ENOTFOUND', 'EAI_AGAIN', 'EHOSTUNREACH']
+
+function isConnectionError (e) {
+  if (!e) return false
+  if (CONNECTION_ERROR_CODES.includes(e.code)) return true
+  return typeof e.message === 'string' && CONNECTION_ERROR_CODES.some(code => e.message.includes(code))
+}
+
 /**
  * Mailer Module
  * @memberof mailer
@@ -99,6 +110,12 @@ class MailerModule extends AbstractModule {
 
       this.log('info', 'email sent successfully')
     } catch (e) {
+      if (isConnectionError(e)) {
+        const connectionUrl = this.getConfig('connectionUrl')
+        this.log('error', `Could not connect to the mail server at ${connectionUrl}; check it is running and connectionUrl is correct. Cause: ${e}`)
+        throw this.app.errors.MAIL_CONNECTION_FAILED.setData({ email: data.to, connectionUrl, error: e })
+      }
+      this.log('error', `Failed to send email to ${data.to}. Cause: ${e}`)
       throw this.app.errors.MAIL_SEND_FAILED.setData({ email: data.to, error: e })
     }
   }

--- a/tests/MailerModule.spec.js
+++ b/tests/MailerModule.spec.js
@@ -40,6 +40,7 @@ const mockApp = {
   onReady: mock.fn(async () => {}),
   errors: {
     MAIL_NOT_ENABLED: Object.assign(new Error('Mail not enabled'), { setData: (d) => d }),
+    MAIL_CONNECTION_FAILED: { setData: (d) => Object.assign(new Error('Mail connection failed'), d) },
     MAIL_SEND_FAILED: { setData: (d) => Object.assign(new Error('Mail send failed'), d) }
   },
   dependencyloader: {
@@ -362,6 +363,43 @@ describe('MailerModule', () => {
         assert.fail('should have thrown')
       } catch (e) {
         assert.equal(e.email, 'user@test.com')
+        assert.ok(e.error instanceof Error)
+      }
+    })
+
+    it('should throw MAIL_CONNECTION_FAILED when the transport errors with a connection code', async () => {
+      mailer.transports.smtp = {
+        name: 'smtp',
+        send: mock.fn(async () => { throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }) })
+      }
+      await assert.rejects(
+        () => mailer.send({ to: 'user@test.com', subject: 'Hi' }),
+        { message: 'Mail connection failed' }
+      )
+    })
+
+    it('should detect connection failures by message when no code is set', async () => {
+      mailer.transports.smtp = {
+        name: 'smtp',
+        send: mock.fn(async () => { throw new Error('getaddrinfo ENOTFOUND smtp.example.com') })
+      }
+      await assert.rejects(
+        () => mailer.send({ to: 'user@test.com', subject: 'Hi' }),
+        { message: 'Mail connection failed' }
+      )
+    })
+
+    it('should include the connectionUrl in MAIL_CONNECTION_FAILED data', async () => {
+      mailer.transports.smtp = {
+        name: 'smtp',
+        send: mock.fn(async () => { throw Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }) })
+      }
+      try {
+        await mailer.send({ to: 'user@test.com', subject: 'Hi' })
+        assert.fail('should have thrown')
+      } catch (e) {
+        assert.equal(e.email, 'user@test.com')
+        assert.equal(e.connectionUrl, 'smtp://localhost')
         assert.ok(e.error instanceof Error)
       }
     })


### PR DESCRIPTION
### Update
When `send()` fails, the underlying transport error is wrapped in a generic `MAIL_SEND_FAILED` whose cause is buried in `.data.error` and never logged. This makes the most common operational failure — **the mail server being unreachable** (e.g. `ECONNREFUSED` when no SMTP server is listening) — indistinguishable from a rejected message, and hard to diagnose from logs.

This PR:
- Adds a distinct **`MAIL_CONNECTION_FAILED`** error (502) thrown when the transport error is a connection failure (`ECONNREFUSED`, `ETIMEDOUT`, `ESOCKET`, `ENOTFOUND`, `EAI_AGAIN`, etc.), with `connectionUrl` included in its data.
- **Logs the underlying cause** in both branches (connection vs. other), instead of silently discarding it.
- Fixes a typo in the `MAIL_SEND_FAILED` description ("send error email" → "send email").

Behaviour is unchanged for non-connection failures (rejected message, schema validation) — they still throw `MAIL_SEND_FAILED`, now with the cause logged.

### Testing
- New `MailerModule` specs: connection error by code, connection error detected by message, and `connectionUrl` present in `MAIL_CONNECTION_FAILED` data.
- Existing send-failure / validation specs still assert `MAIL_SEND_FAILED` (codeless errors are unaffected).
- `npx standard` passes.